### PR TITLE
Allow use of function for argument

### DIFF
--- a/clipboard.js
+++ b/clipboard.js
@@ -31,6 +31,9 @@
     return function(data) {
       return new Promise(function(resolve, reject) {
         _intercept = true;
+        if (typeof data === "function") {
+            data = data();
+        }
         if (typeof data === "string") {
           _data = {"text/plain": data};
         } else if (data instanceof Node) {


### PR DESCRIPTION
I initially assumed I could pass a function and was surprised it wasn't in there! This seems like a low-impact way to add that idiom to the interface.