### PR TITLE
Check if document is defined

### DIFF
--- a/clipboard.js
+++ b/clipboard.js
@@ -4,7 +4,7 @@
     else if (typeof define === "function" && typeof define.amd === "object") { define(definition); }
     else { this[name] = definition(); }
 }("clipboard", function() {
-  if (!document.addEventListener) {
+  if (typeof document === 'undefined' || !document.addEventListener) {
     return null;
   }
 


### PR DESCRIPTION
allows importing in a node environment

This lets me run tests on my code that imports clipboard-js; it refuses to compile in the node environment otherwise.
